### PR TITLE
fix(aios-search): non-blocking lifespan so /health binds during embeddings outages

### DIFF
--- a/aios-search/src/aios_search/api.py
+++ b/aios-search/src/aios_search/api.py
@@ -3,7 +3,7 @@ import threading
 from pathlib import Path
 
 import frontmatter
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -92,12 +92,25 @@ def create_router(
         }
 
     @router.get("/health")
-    def health():
+    def health(request: Request):
+        reconcile = getattr(request.app.state, "reconcile", None)
+        reconcile_info = {
+            "stage": getattr(reconcile, "stage", "unknown"),
+            "error": getattr(reconcile, "error", None),
+        }
         try:
             stats = indexer.get_stats()
-            return {**stats, "healthy": True}
-        except Exception as e:
-            return {"healthy": False, "error": str(e)}
+            indexer_info: dict = {"available": True, **stats}
+        except Exception as exc:
+            indexer_info = {
+                "available": False,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        return {
+            "healthy": True,
+            "reconcile": reconcile_info,
+            "indexer": indexer_info,
+        }
 
     @router.post("/reindex", status_code=202)
     def reindex(_=Depends(auth)):

--- a/aios-search/src/aios_search/main.py
+++ b/aios-search/src/aios_search/main.py
@@ -1,5 +1,8 @@
+import asyncio
 import logging
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
 
 import uvicorn
 from fastapi import FastAPI
@@ -17,32 +20,89 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def create_app(settings: Settings | None = None) -> FastAPI:
+@dataclass
+class ReconcileState:
+    # Kubernetes probes hit /health before the background startup finishes, so the
+    # stage is what they see while the backing services come up.
+    stage: str = "pending"
+    error: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+
+
+async def _run_startup(indexer: Indexer, watcher: Watcher, state: ReconcileState) -> None:
+    loop = asyncio.get_running_loop()
+    state.started_at = datetime.now(timezone.utc).isoformat()
+    try:
+        state.stage = "ensuring_collection"
+        await loop.run_in_executor(None, indexer.ensure_collection)
+
+        state.stage = "reconciling"
+        await loop.run_in_executor(None, watcher.reconcile)
+
+        state.stage = "watching"
+        watcher.start()
+        state.completed_at = datetime.now(timezone.utc).isoformat()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        state.stage = "error"
+        state.error = f"{type(exc).__name__}: {exc}"
+        logger.exception("Startup background task failed; /health remains reachable")
+
+
+def create_app(
+    settings: Settings | None = None,
+    indexer_override: Indexer | None = None,
+    watcher_override: Watcher | None = None,
+) -> FastAPI:
     if settings is None:
         settings = Settings()
 
-    embedder = Embedder(
-        base_url=settings.embedding_url,
-        model_name=settings.embedding_model,
+    if indexer_override is None:
+        embedder = Embedder(
+            base_url=settings.embedding_url,
+            model_name=settings.embedding_model,
+        )
+        indexer = Indexer(
+            database_url=settings.database_url,
+            embedder=embedder,
+            batch_size=settings.upsert_batch_size,
+        )
+    else:
+        indexer = indexer_override
+
+    watcher = watcher_override if watcher_override is not None else Watcher(
+        settings=settings, indexer=indexer
     )
-    indexer = Indexer(
-        database_url=settings.database_url,
-        embedder=embedder,
-        batch_size=settings.upsert_batch_size,
-    )
-    watcher = Watcher(settings=settings, indexer=indexer)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         logger.info("Starting AIOS Search...")
-        indexer.ensure_collection()
-        watcher.reconcile()
-        watcher.start()
-        logger.info("AIOS Search ready")
-        yield
-        logger.info("Shutting down...")
-        watcher.stop()
-        indexer.close()
+        state = ReconcileState()
+        app.state.reconcile = state
+        task = asyncio.create_task(_run_startup(indexer, watcher, state))
+        app.state.reconcile_task = task
+        logger.info("AIOS Search HTTP ready; reconcile continues in background")
+        try:
+            yield
+        finally:
+            logger.info("Shutting down...")
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    logger.exception("Startup task errored during shutdown")
+            watcher.stop()
+            close = getattr(indexer, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    logger.exception("Indexer close failed during shutdown")
 
     app = FastAPI(title="AIOS Search", version="0.1.0", lifespan=lifespan)
     router = create_router(

--- a/aios-search/src/aios_search/watcher.py
+++ b/aios-search/src/aios_search/watcher.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from watchfiles import Change, watch
@@ -12,13 +13,23 @@ from aios_search.parser import parse_note, should_ignore
 
 logger = logging.getLogger(__name__)
 
+_RETRY_BASE_SECONDS = 30.0
+_RETRY_MAX_SECONDS = 3600.0
+
+
+@dataclass
+class _RetryInfo:
+    attempts: int = 0
+    next_retry_at: float = 0.0  # time.monotonic() reference
+    last_error: str = ""
+
 
 class Watcher:
     def __init__(self, settings: Settings, indexer: Indexer):
         self._settings = settings
         self._indexer = indexer
         self._vault = Path(settings.vault_path)
-        self._retry_set: set[str] = set()
+        self._retry_state: dict[str, _RetryInfo] = {}
         self._paused = False
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
@@ -40,6 +51,9 @@ class Watcher:
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
+    def has_pending_retry(self, rel_path: str) -> bool:
+        return rel_path in self._retry_state
+
     def _should_ignore(self, path: Path) -> bool:
         return should_ignore(
             path,
@@ -48,7 +62,36 @@ class Watcher:
             self._settings.ignored_files,
         )
 
+    def _record_failure(self, rel_path: str, exc: Exception) -> None:
+        info = self._retry_state.get(rel_path)
+        first_failure = info is None
+        if info is None:
+            info = _RetryInfo()
+            self._retry_state[rel_path] = info
+        info.attempts += 1
+        backoff = min(
+            _RETRY_BASE_SECONDS * (2 ** (info.attempts - 1)),
+            _RETRY_MAX_SECONDS,
+        )
+        info.next_retry_at = time.monotonic() + backoff
+        info.last_error = f"{type(exc).__name__}: {exc}"
+        if first_failure:
+            logger.exception(
+                "Failed to index %s (first failure, next retry in %ds)",
+                rel_path,
+                int(backoff),
+            )
+        else:
+            logger.warning(
+                "Failed to index %s (attempt %d, next retry in %ds): %s",
+                rel_path,
+                info.attempts,
+                int(backoff),
+                info.last_error,
+            )
+
     def _process_file(self, path: Path):
+        rel_path = str(path.relative_to(self._vault))
         try:
             chunks = parse_note(
                 path,
@@ -57,31 +100,36 @@ class Watcher:
                 chunk_word_window=self._settings.chunk_word_window,
                 chunk_word_overlap=self._settings.chunk_word_overlap,
             )
-            rel_path = str(path.relative_to(self._vault))
             self._indexer.delete_by_file_path(rel_path)
             self._indexer.upsert_chunks(chunks)
-            self._retry_set.discard(rel_path)
-        except Exception:
-            rel_path = str(path.relative_to(self._vault))
-            self._retry_set.add(rel_path)
-            logger.exception("Failed to index %s, added to retry set", rel_path)
+            self._retry_state.pop(rel_path, None)
+        except Exception as exc:
+            self._record_failure(rel_path, exc)
 
     def _process_delete(self, path: Path):
         try:
             rel_path = str(path.relative_to(self._vault))
             self._indexer.delete_by_file_path(rel_path)
-            self._retry_set.discard(rel_path)
+            self._retry_state.pop(rel_path, None)
         except Exception:
             logger.exception("Failed to delete vectors for %s", path)
 
     def _process_retries(self):
-        if not self._retry_set:
+        if not self._retry_state:
             return
-        for rel_path in list(self._retry_set):
+        now = time.monotonic()
+        due = [
+            rel_path
+            for rel_path, info in list(self._retry_state.items())
+            if info.next_retry_at <= now
+        ]
+        for rel_path in due:
             path = self._vault / rel_path
             if path.is_file():
                 logger.info("Retrying %s", rel_path)
                 self._process_file(path)
+            else:
+                self._retry_state.pop(rel_path, None)
 
     def reconcile(self):
         logger.info("Starting reconciliation...")
@@ -109,9 +157,10 @@ class Watcher:
             self._process_file(path)
 
         logger.info(
-            "Reconciliation complete: %d indexed, %d orphans removed",
+            "Reconciliation complete: %d indexed, %d orphans removed, %d pending retry",
             len(to_index),
             len(set(indexed) - set(vault_files)),
+            len(self._retry_state),
         )
 
     def full_reindex(self):

--- a/aios-search/tests/test_api.py
+++ b/aios-search/tests/test_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -125,7 +125,41 @@ def test_get_note_not_found(client):
 def test_health_no_auth_required(client):
     resp = client.get("/health")
     assert resp.status_code == 200
-    assert "total_points" in resp.json()
+    body = resp.json()
+    assert body["healthy"] is True
+    assert body["indexer"]["available"] is True
+    assert body["indexer"]["total_points"] == 100
+
+
+def test_health_200_when_indexer_unavailable(client, mock_indexer):
+    mock_indexer.get_stats.side_effect = RuntimeError("qdrant down")
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["healthy"] is True
+    assert body["indexer"]["available"] is False
+    assert "qdrant down" in body["indexer"]["error"]
+
+
+def test_health_reports_reconcile_state(mock_indexer, tmp_vault):
+    from aios_search.api import create_router
+    from aios_search.main import ReconcileState
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    router = create_router(
+        indexer=mock_indexer,
+        vault_path=str(tmp_vault),
+        api_key="test-key",
+    )
+    app.include_router(router)
+    app.state.reconcile = ReconcileState(stage="reconciling")
+    with TestClient(app) as c:
+        resp = c.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["reconcile"]["stage"] == "reconciling"
+    assert body["reconcile"]["error"] is None
 
 
 def test_reindex(client, mock_indexer):

--- a/aios-search/tests/test_main.py
+++ b/aios-search/tests/test_main.py
@@ -1,0 +1,137 @@
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app_factory(monkeypatch, tmp_vault):
+    from aios_search.config import Settings
+    from aios_search.main import create_app
+
+    monkeypatch.setenv("VAULT_PATH", str(tmp_vault))
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost:5432/aios")
+    monkeypatch.setenv("AIOS_API_KEY", "secret")
+
+    created = {}
+
+    def factory(indexer=None, watcher=None):
+        settings = Settings()
+        app = create_app(
+            settings=settings,
+            indexer_override=indexer,
+            watcher_override=watcher,
+        )
+        created["app"] = app
+        return app
+
+    return factory
+
+
+@pytest.fixture
+def fake_indexer():
+    indexer = MagicMock()
+    indexer.get_stats.return_value = {
+        "total_points": 42,
+        "status": "green",
+        "last_indexed_at": None,
+    }
+    indexer.get_indexed_files.return_value = {}
+    return indexer
+
+
+class _FakeWatcher:
+    def __init__(self, reconcile_block_seconds: float = 0.0, reconcile_raises: Exception | None = None):
+        self._reconcile_block_seconds = reconcile_block_seconds
+        self._reconcile_raises = reconcile_raises
+        self.started = False
+        self.stopped = False
+        self.reconcile_called = threading.Event()
+        self.reconcile_finished = threading.Event()
+
+    def reconcile(self):
+        self.reconcile_called.set()
+        if self._reconcile_block_seconds:
+            time.sleep(self._reconcile_block_seconds)
+        if self._reconcile_raises:
+            raise self._reconcile_raises
+        self.reconcile_finished.set()
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def full_reindex(self):
+        pass
+
+
+def test_lifespan_does_not_block_on_slow_reconcile(app_factory, fake_indexer):
+    """
+    Regression for #1425: lifespan must not wait for reconcile to complete.
+    If reconcile blocks (e.g. embeddings backend down), /health must still bind.
+    """
+    watcher = _FakeWatcher(reconcile_block_seconds=5.0)
+    app = app_factory(indexer=fake_indexer, watcher=watcher)
+
+    start = time.monotonic()
+    with TestClient(app) as client:
+        elapsed = time.monotonic() - start
+        # TestClient completes lifespan startup before returning from __enter__.
+        # If reconcile were awaited synchronously, this would take ~5s.
+        assert elapsed < 2.0, f"Lifespan took {elapsed:.2f}s; reconcile is blocking startup"
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+
+def test_lifespan_starts_reconcile_in_background(app_factory, fake_indexer):
+    watcher = _FakeWatcher()
+    app = app_factory(indexer=fake_indexer, watcher=watcher)
+
+    with TestClient(app):
+        # Reconcile runs in a background task; it should be dispatched by now.
+        assert watcher.reconcile_called.wait(timeout=5.0)
+        assert watcher.reconcile_finished.wait(timeout=5.0)
+
+
+def test_lifespan_tolerates_reconcile_failure(app_factory, fake_indexer):
+    """
+    AC1: pod reaches Ready even when embeddings backend is down.
+    The background reconcile may raise; the app must keep serving.
+    """
+    watcher = _FakeWatcher(reconcile_raises=RuntimeError("embeddings backend 500"))
+    app = app_factory(indexer=fake_indexer, watcher=watcher)
+
+    with TestClient(app) as client:
+        assert watcher.reconcile_called.wait(timeout=5.0)
+        # Give the background task a moment to record the error
+        time.sleep(0.2)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reconcile"]["stage"] == "error"
+        assert "embeddings backend 500" in body["reconcile"]["error"]
+
+
+def test_lifespan_tolerates_ensure_collection_failure(app_factory, fake_indexer):
+    fake_indexer.ensure_collection.side_effect = RuntimeError("qdrant unreachable")
+    watcher = _FakeWatcher()
+    app = app_factory(indexer=fake_indexer, watcher=watcher)
+
+    with TestClient(app) as client:
+        time.sleep(0.2)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reconcile"]["stage"] == "error"
+
+
+def test_lifespan_stops_watcher_on_shutdown(app_factory, fake_indexer):
+    watcher = _FakeWatcher()
+    app = app_factory(indexer=fake_indexer, watcher=watcher)
+    with TestClient(app):
+        pass
+    assert watcher.stopped

--- a/aios-search/tests/test_watcher.py
+++ b/aios-search/tests/test_watcher.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, call
 
@@ -44,7 +45,63 @@ def test_process_file_adds_to_retry_on_failure(watcher, mock_indexer, tmp_vault)
     mock_indexer.upsert_chunks.side_effect = Exception("database unavailable")
     path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
     watcher._process_file(path)
-    assert "12-CRM/Contacts/Shah Ali.md" in watcher._retry_set
+    assert watcher.has_pending_retry("12-CRM/Contacts/Shah Ali.md")
+
+
+def test_process_file_first_failure_logs_exception_with_traceback(watcher, mock_indexer, tmp_vault, caplog):
+    mock_indexer.upsert_chunks.side_effect = Exception("Qdrant down")
+    path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
+    with caplog.at_level(logging.WARNING, logger="aios_search.watcher"):
+        watcher._process_file(path)
+    exception_records = [r for r in caplog.records if r.exc_info is not None]
+    assert len(exception_records) == 1, "first failure should log with traceback"
+
+
+def test_process_file_subsequent_failures_suppress_traceback(watcher, mock_indexer, tmp_vault, caplog):
+    mock_indexer.upsert_chunks.side_effect = Exception("Qdrant down")
+    path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
+    watcher._process_file(path)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="aios_search.watcher"):
+        watcher._process_file(path)
+        watcher._process_file(path)
+    exception_records = [r for r in caplog.records if r.exc_info is not None]
+    assert exception_records == [], "repeat failures must not re-log full tracebacks"
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warning_records, "repeat failures should still surface a warning line"
+
+
+def test_process_file_success_clears_retry(watcher, mock_indexer, tmp_vault):
+    mock_indexer.upsert_chunks.side_effect = Exception("transient")
+    path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
+    watcher._process_file(path)
+    assert watcher.has_pending_retry("12-CRM/Contacts/Shah Ali.md")
+    mock_indexer.upsert_chunks.side_effect = None
+    watcher._process_file(path)
+    assert not watcher.has_pending_retry("12-CRM/Contacts/Shah Ali.md")
+
+
+def test_process_retries_respects_backoff(watcher, mock_indexer, tmp_vault):
+    mock_indexer.upsert_chunks.side_effect = Exception("Qdrant down")
+    path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
+    watcher._process_file(path)
+    initial_call_count = mock_indexer.upsert_chunks.call_count
+    # Immediately calling _process_retries should NOT retry: backoff hasn't elapsed.
+    watcher._process_retries()
+    assert mock_indexer.upsert_chunks.call_count == initial_call_count
+
+
+def test_process_retries_fires_when_backoff_elapsed(watcher, mock_indexer, tmp_vault, monkeypatch):
+    mock_indexer.upsert_chunks.side_effect = Exception("Qdrant down")
+    path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
+    watcher._process_file(path)
+    # Force the backoff to elapse by fast-forwarding the monotonic clock.
+    from aios_search import watcher as watcher_mod
+    original = watcher_mod.time.monotonic
+    monkeypatch.setattr(watcher_mod.time, "monotonic", lambda: original() + 3600)
+    call_count_before = mock_indexer.upsert_chunks.call_count
+    watcher._process_retries()
+    assert mock_indexer.upsert_chunks.call_count > call_count_before
 
 
 def test_process_delete(watcher, mock_indexer, tmp_vault):


### PR DESCRIPTION
## Summary

- Decouples initial reconciliation from the FastAPI lifespan so `/health` binds immediately, satisfying the Kubernetes startup probe even when the embeddings backend is flaky.
- `/health` now always returns **200** with a `reconcile.stage` breakdown (`pending | ensuring_collection | reconciling | watching | error`) and an `indexer.available` flag, so probes can distinguish *initializing* from *ready*.
- Replaces the unbounded retry set in the watcher with per-file exponential backoff (30s base, 1h cap). First failure keeps the traceback; subsequent failures log a single warning with the next retry window, killing the uninterrupted traceback stream.

Closes Diixtra/diixtra-forge#1425

## Why

`aios-search` was restarting every few minutes (682 restarts / 46h observed on `aios-search-7bbf445474-bpflg`) because the lifespan `await watcher.reconcile()` looped forever retrying against `local-ai`. FastAPI does not serve traffic until the lifespan startup phase completes, so `/health` never bound on `:8000` and `kubelet` reported `connection refused`.

## Acceptance criteria mapping

- [x] **Pod reaches `Ready=True` within the startup-probe budget even if embeddings is down** — lifespan yields immediately after dispatching `_run_startup` as an `asyncio` task.
- [x] **`/health` returns 200 as soon as DB + HTTP are up, independent of vault reconciliation** — `health()` wraps `indexer.get_stats()` defensively and reports `indexer.available=false` rather than raising.
- [x] **Reconciliation failures logged once per file with retry scheduling, not an uninterrupted traceback stream** — `_record_failure` in `Watcher` emits a traceback on first failure only; subsequent attempts log a single `WARNING` line with `next retry in Xs`.

## Test plan

- [x] `uv run pytest tests/` — 62 passed, coverage 89.78% (watcher 78%, api 93%, overall 90%).
- [x] New `test_main.py` asserts the lifespan completes in <2s even with a 5s-blocking reconcile, tolerates `ensure_collection` and `reconcile` failures, and stops the watcher on shutdown.
- [x] New `test_api.py` cases assert `/health` returns 200 when `indexer.get_stats()` raises and surfaces `reconcile.stage`.
- [x] New `test_watcher.py` cases assert first-failure tracebacks, dedup on repeat failures, success clears retry state, and backoff gates `_process_retries`.
- [ ] After merge, let CI rebuild `ghcr.io/diixtra/aios/aios-search:latest`; Flux will roll the pod in `ai` namespace; verify `kubectl get pod -n ai -l app.kubernetes.io/name=aios-search` stabilises and `curl /health` returns 200 with `reconcile.stage` progressing `ensuring_collection → reconciling → watching`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)