### PR TITLE
feat(ci): flip code-quality mode to enforce (#115)

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -18,4 +18,4 @@ jobs:
   code-quality:
     uses: Diixtra/diixtra-forge/.github/workflows/code-quality.yaml@main
     with:
-      mode: observe
+      mode: enforce


### PR DESCRIPTION
## Summary

Flip the aios code-quality caller workflow from `mode: observe` to `mode: enforce`, gating PRs on lint/security/code-quality findings.

## Prerequisites (both merged on diixtra-forge main)

- Diixtra/diixtra-forge#1659 — T5.5: matrix-per-workspace for monorepo support (Diixtra/diixtra-forge#1658)
- Diixtra/diixtra-forge#1669 — T5.6: tool-step defects fix (Diixtra/diixtra-forge#1668)
  - golangci-lint v2 args
  - hashFiles guards on all SARIF uploads
  - observe-mode bypass on upload-sarif

## Acceptance

This PR's own CI run validates the matrix expands correctly across `runtime`, `operator`, `ticktick-sync`, `webhook`, `aios-search`, `aios-search/mcp`, `mcp-proxy`, `voice` and surfaces real findings in enforce mode.

If matrix jobs all SUCCEED → merge as-is.
If any job FAILS with a real lint/security finding → open per-finding aios issues, revert this PR to `mode: observe`, then ship the observe-mode caller and defer the enforce flip.

Closes #115. Refs: Diixtra/diixtra-forge#1636.