### PR TITLE
feat: install Lefthook (slot 1) (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ cd webhook && go test ./...
 cd operator && go test ./...
 ```
 
+### Pre-commit hooks
+
+Install once after cloning:
+
+```sh
+mise install
+lefthook install
+```
+
+This wires the org-wide hooks (gitleaks + biome + ruff + gofmt + Conventional Commits) defined in `lefthook.yml`. Hooks run on developer machines; CI re-runs them as a safety net.
+
 ## Deployment
 
 Deployed on a homelab K8s cluster (Forge) via Flux GitOps. Manifests in `k8s/`.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,61 @@
+# Diixtra org-wide pre-commit hooks (multi-language: TS + Python + Go).
+# Source: Diixtra/diixtra-forge/templates/lefthook.yml
+# Run `lefthook install` after `mise install`.
+# Slot 1: fast (<2s) staged-file checks. Anything slower belongs in CI.
+# Reference: docs/code-quality/slot-allocation.md in diixtra-forge.
+
+pre-commit:
+  parallel: true
+  commands:
+
+    # Cross-cutting: secret scan on staged files only
+    gitleaks:
+      glob: "*"
+      run: |
+        if command -v gitleaks >/dev/null; then
+          gitleaks protect --staged --redact --no-banner
+        else
+          echo "gitleaks not installed. Add via mise: mise use -g gitleaks@latest"
+          exit 1
+        fi
+
+    # TS/JS: lint + format on staged files
+    biome:
+      glob: "*.{ts,tsx,js,jsx,json,jsonc}"
+      run: bunx biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+      skip:
+        - merge
+        - rebase
+
+    # Python: lint + format on staged files
+    ruff:
+      glob: "*.py"
+      run: |
+        uv run ruff check --fix {staged_files} && uv run ruff format {staged_files}
+      skip:
+        - merge
+        - rebase
+
+    # Go: format + vet on staged files (golangci-lint full run is in CI)
+    gofmt:
+      glob: "*.go"
+      run: |
+        gofmt -l -w {staged_files}
+        if [ -n "$(gofmt -l {staged_files})" ]; then exit 1; fi
+      skip:
+        - merge
+        - rebase
+
+commit-msg:
+  commands:
+    conventional-commits:
+      run: |
+        commit_msg=$(cat {1})
+        # Skip merge/revert
+        echo "$commit_msg" | grep -qE '^(Merge|Revert)' && exit 0
+        # Conventional Commits regex
+        echo "$commit_msg" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+' || {
+          echo "Commit message must follow Conventional Commits format."
+          echo "Example: 'feat(ci): add lefthook config'"
+          exit 1
+        }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+lefthook = "1.10"
+gitleaks = "8.21"
+bun = "1.3.13"
+go = "1.24"
+uv = "0.5"


### PR DESCRIPTION
## Summary

Install Lefthook on aios per the SOP at https://github.com/Diixtra/diixtra-forge/blob/main/docs/code-quality/pre-commit-rollout.md.

aios is a multi-language monorepo (TS in `runtime/`, Go in `operator/`/`ticktick-sync/`/`webhook/`, Python in `aios-search/` etc.). Hooks cover all three plus secret scanning + commit-msg.

## Changes

- `lefthook.yml` — repo-root config: gitleaks, biome (TS), ruff (Python), gofmt (Go), commit-msg conventional-commits. Rustfmt dropped (no Rust here).
- `mise.toml` — pin `lefthook = "1.10"`, `gitleaks = "8.21"`, plus `bun`, `go`, `uv`.
- `README.md` — add **Pre-commit hooks** sub-section under Development.

Hooks run on developer machines; CI catches anything bypassed locally via the existing observe-mode code-quality workflow.

Closes #121. Refs Diixtra/diixtra-forge#1636 phase C.