### PR TITLE
fix(runtime): add model + maxTokens to pipeline test fixtures (#117)

### DIFF
--- a/runtime/src/pipeline/deliver.test.ts
+++ b/runtime/src/pipeline/deliver.test.ts
@@ -13,6 +13,8 @@ const config: TaskConfig = {
   memoryUrl: "http://memory:8080",
   searchUrl: "http://search:8080",
   workspace: "/workspace",
+  model: "claude-sonnet-4-6",
+  maxTokens: 16384,
 };
 
 const mockGithub = {

--- a/runtime/src/pipeline/plan.test.ts
+++ b/runtime/src/pipeline/plan.test.ts
@@ -12,6 +12,8 @@ const config: TaskConfig = {
   memoryUrl: "http://memory:8080",
   searchUrl: "http://search:8080",
   workspace: "/workspace",
+  model: "claude-sonnet-4-6",
+  maxTokens: 16384,
 };
 
 const mockFabric = {

--- a/runtime/src/pipeline/research.test.ts
+++ b/runtime/src/pipeline/research.test.ts
@@ -18,6 +18,8 @@ const config: TaskConfig = {
   memoryUrl: "http://memory:8080",
   searchUrl: "http://search:8080",
   workspace: "/workspace",
+  model: "claude-sonnet-4-6",
+  maxTokens: 16384,
 };
 
 const mockMemory = {

--- a/runtime/src/pipeline/understand.test.ts
+++ b/runtime/src/pipeline/understand.test.ts
@@ -13,6 +13,8 @@ const config: TaskConfig = {
   memoryUrl: "http://memory:8080",
   searchUrl: "http://search:8080",
   workspace: "/workspace",
+  model: "claude-sonnet-4-6",
+  maxTokens: 16384,
 };
 
 const mockGithub = {

--- a/runtime/src/pipeline/verify.test.ts
+++ b/runtime/src/pipeline/verify.test.ts
@@ -32,6 +32,8 @@ const config: TaskConfig = {
   memoryUrl: "http://memory:8080",
   searchUrl: "http://search:8080",
   workspace: "/workspace",
+  model: "claude-sonnet-4-6",
+  maxTokens: 16384,
 };
 
 const toolPolicy: ToolPolicy = {


### PR DESCRIPTION
## Summary

5 test files in \`src/pipeline/\` had TaskConfig literals missing the required \`model\` and \`maxTokens\` properties. Surfaced by enforce-mode code-quality CI on PR #116.

## Files

- \`src/pipeline/deliver.test.ts\`
- \`src/pipeline/plan.test.ts\`
- \`src/pipeline/research.test.ts\`
- \`src/pipeline/understand.test.ts\`
- \`src/pipeline/verify.test.ts\`

Each gets \`model: "claude-sonnet-4-6"\`, \`maxTokens: 16384\` — matching the runtime's \`loadTaskConfig\` defaults.

\`tsc --noEmit\` clean.

Closes #117. Refs Diixtra/diixtra-forge#1636.