### PR TITLE
fix(operator): migrate .golangci.yml to v2 format (#119)

### DIFF
--- a/operator/.golangci.yml
+++ b/operator/.golangci.yml
@@ -1,33 +1,18 @@
+version: "2"
+
 run:
   timeout: 5m
   allow-parallel-runners: true
 
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
 linters:
-  disable-all: true
+  default: none
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - copyloopvar
     - ginkgolinter
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -36,12 +21,24 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-
-linters-settings:
-  revive:
+  exclusions:
     rules:
-      - name: comment-spacings
+      - path: "api/*"
+        linters:
+          - lll
+      - path: "internal/*"
+        linters:
+          - dupl
+          - lll
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+
+formatters:
+  enable:
+    - gofmt
+    - goimports


### PR DESCRIPTION
## Summary

The reusable code-quality workflow pins golangci-lint v2.11.4. \`operator/.golangci.yml\` was in v1 format and v2 rejects it with \"unsupported version of the configuration\".

## Changes

\`operator/.golangci.yml\` migrated per https://golangci-lint.run/product/migration-guide/:

- Add explicit \`version: "2"\` field
- \`disable-all: true\` → \`linters.default: none\`
- \`issues.exclude-rules\` → \`linters.exclusions.rules\`
- \`linters-settings\` → \`linters.settings\`
- Drop \`gosimple\`, \`typecheck\` (merged into \`staticcheck\` in v2)
- Move \`gofmt\`, \`goimports\` to dedicated \`formatters\` section

## Note on the other Go sub-packages

\`ticktick-sync\` and \`webhook\` have no \`.golangci.yml\` — v2 uses its default linter set when no config is present, so no migration is required there. Their earlier failures in CI run 25176414794 were the now-resolved \`--output.formats\` flag issue (Diixtra/diixtra-forge#1668, fixed in #1669).

Closes #119. Refs Diixtra/diixtra-forge#1636.