### PR TITLE
feat(ci): flip code-quality mode to enforce (#115)

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -18,4 +18,4 @@ jobs:
   code-quality:
     uses: Diixtra/diixtra-forge/.github/workflows/code-quality.yaml@main
     with:
-      mode: observe
+      mode: enforce


### PR DESCRIPTION
## Summary

Flip the aios code-quality caller workflow from \`mode: observe\` to \`mode: enforce\`.

## Blockers resolved (per #115 triage)

- ✅ #117 — TS2739 type errors fixed (5 \`src/pipeline/*.test.ts\` fixtures got \`model\` + \`maxTokens\`)
- ✅ #118 — \`uv.lock\` added to \`aios-search/\`, \`aios-search/mcp/\`, \`mcp-proxy/\`, \`voice/\`
- ✅ #119 — \`operator/.golangci.yml\` migrated to v2 format
- ✅ Diixtra/diixtra-forge#1671 — kube-score Helm-template fix landed
- ✅ Diixtra/aios#123 — ruleset path-filter unblocked

## Acceptance

This PR's own CI run validates the matrix expands correctly across \`runtime\`, \`operator\`, \`ticktick-sync\`, \`webhook\`, \`aios-search\`, \`aios-search/mcp\`, \`mcp-proxy\`, \`voice\` AND that enforce mode passes on real findings.

Closes #115. Refs Diixtra/diixtra-forge#1636.