### PR TITLE
fix: ruff clean across 4 Python sub-packages (#115)

### DIFF
--- a/aios-search/src/aios_search/indexer.py
+++ b/aios-search/src/aios_search/indexer.py
@@ -92,9 +92,7 @@ class Indexer:
         vectors = self._embedder.embed(texts)
         rows: list[tuple] = []
         for chunk, vector in zip(chunks, vectors):
-            metadata_payload = {
-                k: v for k, v in chunk.metadata.items() if k != "title"
-            }
+            metadata_payload = {k: v for k, v in chunk.metadata.items() if k != "title"}
             rows.append(
                 (
                     chunk.file_path,
@@ -231,9 +229,7 @@ class Indexer:
 
     # Internals ---------------------------------------------------------
 
-    def _filter_where_parts(
-        self, filters: dict | None, params: list[Any]
-    ) -> list[str]:
+    def _filter_where_parts(self, filters: dict | None, params: list[Any]) -> list[str]:
         """Translate a filter dict into SQL predicates.
 
         Qdrant's ``MatchValue`` matched scalar-against-scalar and
@@ -249,8 +245,7 @@ class Indexer:
             if value is None:
                 continue
             parts.append(
-                "((metadata->>%s) = %s "
-                "OR (metadata->%s) @> to_jsonb(%s::text))"
+                "((metadata->>%s) = %s OR (metadata->%s) @> to_jsonb(%s::text))"
             )
             params.extend([key, str(value), key, str(value)])
         return parts

--- a/aios-search/src/aios_search/main.py
+++ b/aios-search/src/aios_search/main.py
@@ -30,7 +30,9 @@ class ReconcileState:
     completed_at: str | None = None
 
 
-async def _run_startup(indexer: Indexer, watcher: Watcher, state: ReconcileState) -> None:
+async def _run_startup(
+    indexer: Indexer, watcher: Watcher, state: ReconcileState
+) -> None:
     loop = asyncio.get_running_loop()
     state.started_at = datetime.now(timezone.utc).isoformat()
     try:
@@ -72,8 +74,10 @@ def create_app(
     else:
         indexer = indexer_override
 
-    watcher = watcher_override if watcher_override is not None else Watcher(
-        settings=settings, indexer=indexer
+    watcher = (
+        watcher_override
+        if watcher_override is not None
+        else Watcher(settings=settings, indexer=indexer)
     )
 
     @asynccontextmanager

--- a/aios-search/src/aios_search/parser.py
+++ b/aios-search/src/aios_search/parser.py
@@ -1,6 +1,6 @@
 import hashlib
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import frontmatter
@@ -60,9 +60,7 @@ def _split_by_headings(body: str) -> list[str]:
     return [s.strip() for s in sections if s.strip()]
 
 
-def _split_by_word_window(
-    text: str, window: int = 200, overlap: int = 30
-) -> list[str]:
+def _split_by_word_window(text: str, window: int = 200, overlap: int = 30) -> list[str]:
     words = text.split()
     if len(words) <= window:
         return [text]

--- a/aios-search/tests/conftest.py
+++ b/aios-search/tests/conftest.py
@@ -1,7 +1,3 @@
-import os
-import tempfile
-from pathlib import Path
-
 import pytest
 
 
@@ -46,8 +42,7 @@ def tmp_vault(tmp_path):
         "type: framework\n"
         "entity: [group]\n"
         "status: active\n"
-        "---\n\n"
-        + "This is a business framework for evaluating acquisitions. " * 40
+        "---\n\n" + "This is a business framework for evaluating acquisitions. " * 40
     )
     (knowledge / "Business Framework.md").write_text(no_heading_content)
 

--- a/aios-search/tests/test_api.py
+++ b/aios-search/tests/test_api.py
@@ -69,7 +69,11 @@ def test_search(client, mock_indexer):
 def test_search_with_filters(client, mock_indexer):
     resp = client.post(
         "/search",
-        json={"query": "IDOX", "limit": 3, "filters": {"type": "meeting", "entity": "diixtra"}},
+        json={
+            "query": "IDOX",
+            "limit": 3,
+            "filters": {"type": "meeting", "entity": "diixtra"},
+        },
         headers={"Authorization": "Bearer test-key"},
     )
     assert resp.status_code == 200

--- a/aios-search/tests/test_auth.py
+++ b/aios-search/tests/test_auth.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi import FastAPI, Depends
 from fastapi.testclient import TestClient
 

--- a/aios-search/tests/test_embedder.py
+++ b/aios-search/tests/test_embedder.py
@@ -9,17 +9,16 @@ from aios_search.embedder import Embedder
 @pytest.fixture
 def mock_response():
     """Create a mock httpx response with embedding data."""
+
     def _make(embeddings: list[list[float]]):
         resp = MagicMock()
         resp.status_code = 200
         resp.raise_for_status = MagicMock()
         resp.json.return_value = {
-            "data": [
-                {"embedding": emb, "index": i}
-                for i, emb in enumerate(embeddings)
-            ]
+            "data": [{"embedding": emb, "index": i} for i, emb in enumerate(embeddings)]
         }
         return resp
+
     return _make
 
 

--- a/aios-search/tests/test_indexer.py
+++ b/aios-search/tests/test_indexer.py
@@ -4,6 +4,7 @@ We stand up a real pgvector/pgvector:pg18 testcontainer and apply the
 production schema.sql once per session. Each test runs in a transaction
 that is rolled back so assertions stay isolated.
 """
+
 import os
 
 import numpy as np
@@ -124,10 +125,20 @@ def test_ensure_collection_raises_when_table_missing(pg_container):
 
 def test_upsert_and_search_roundtrip(indexer):
     chunks = [
-        _chunk("20-Meetings/idox.md", 0, "IDOX migration discussion", title="IDOX Meeting",
-               metadata={"type": "meeting", "entity": ["diixtra"], "status": "done"}),
-        _chunk("10-Projects/website.md", 0, "New marketing website project", title="Website",
-               metadata={"type": "project", "entity": ["kazie"], "status": "active"}),
+        _chunk(
+            "20-Meetings/idox.md",
+            0,
+            "IDOX migration discussion",
+            title="IDOX Meeting",
+            metadata={"type": "meeting", "entity": ["diixtra"], "status": "done"},
+        ),
+        _chunk(
+            "10-Projects/website.md",
+            0,
+            "New marketing website project",
+            title="Website",
+            metadata={"type": "project", "entity": ["kazie"], "status": "active"},
+        ),
     ]
     indexer.upsert_chunks(chunks)
 
@@ -163,10 +174,12 @@ def test_upsert_updates_existing_row(indexer):
 
 
 def test_delete_by_file_path(indexer):
-    indexer.upsert_chunks([
-        _chunk("a.md", 0, "Alpha"),
-        _chunk("b.md", 0, "Bravo"),
-    ])
+    indexer.upsert_chunks(
+        [
+            _chunk("a.md", 0, "Alpha"),
+            _chunk("b.md", 0, "Bravo"),
+        ]
+    )
     indexer.delete_by_file_path("a.md")
     assert indexer.get_stats()["total_points"] == 1
     files = indexer.get_indexed_files()
@@ -175,39 +188,51 @@ def test_delete_by_file_path(indexer):
 
 
 def test_get_indexed_files_returns_hashes(indexer):
-    indexer.upsert_chunks([
-        _chunk("a.md", 0, "Alpha"),
-        _chunk("b.md", 0, "Bravo"),
-    ])
+    indexer.upsert_chunks(
+        [
+            _chunk("a.md", 0, "Alpha"),
+            _chunk("b.md", 0, "Bravo"),
+        ]
+    )
     files = indexer.get_indexed_files()
     assert files == {"a.md": "hash-a.md-0", "b.md": "hash-b.md-0"}
 
 
 def test_search_filters_scalar_metadata(indexer):
-    indexer.upsert_chunks([
-        _chunk("a.md", 0, "Note about IDOX", metadata={"type": "meeting"}),
-        _chunk("b.md", 0, "Note about IDOX", metadata={"type": "project"}),
-    ])
-    results = indexer.search("IDOX", limit=5, min_score=0.0, filters={"type": "meeting"})
+    indexer.upsert_chunks(
+        [
+            _chunk("a.md", 0, "Note about IDOX", metadata={"type": "meeting"}),
+            _chunk("b.md", 0, "Note about IDOX", metadata={"type": "project"}),
+        ]
+    )
+    results = indexer.search(
+        "IDOX", limit=5, min_score=0.0, filters={"type": "meeting"}
+    )
     assert len(results) == 1
     assert results[0]["file_path"] == "a.md"
 
 
 def test_search_filters_array_metadata(indexer):
-    indexer.upsert_chunks([
-        _chunk("a.md", 0, "Project X", metadata={"entity": ["diixtra", "kazie"]}),
-        _chunk("b.md", 0, "Project X", metadata={"entity": ["other"]}),
-    ])
-    results = indexer.search("Project X", limit=5, min_score=0.0, filters={"entity": "diixtra"})
+    indexer.upsert_chunks(
+        [
+            _chunk("a.md", 0, "Project X", metadata={"entity": ["diixtra", "kazie"]}),
+            _chunk("b.md", 0, "Project X", metadata={"entity": ["other"]}),
+        ]
+    )
+    results = indexer.search(
+        "Project X", limit=5, min_score=0.0, filters={"entity": "diixtra"}
+    )
     assert len(results) == 1
     assert results[0]["file_path"] == "a.md"
 
 
 def test_find_similar_excludes_source(indexer):
-    indexer.upsert_chunks([
-        _chunk("a.md", 0, "IDOX migration timeline"),
-        _chunk("b.md", 0, "IDOX migration milestones"),
-    ])
+    indexer.upsert_chunks(
+        [
+            _chunk("a.md", 0, "IDOX migration timeline"),
+            _chunk("b.md", 0, "IDOX migration milestones"),
+        ]
+    )
     results = indexer.find_similar("a.md", limit=5, min_score=0.0)
     assert results is not None
     file_paths = [r["file_path"] for r in results]
@@ -240,10 +265,12 @@ def test_upsert_empty_chunks_is_noop(indexer):
 def test_search_respects_min_score(indexer):
     # All the deterministic embedder's vectors map similar chars to similar
     # coordinates, so a very high min_score should drop unrelated results.
-    indexer.upsert_chunks([
-        _chunk("a.md", 0, "alpha"),
-        _chunk("b.md", 0, "zzzzz"),
-    ])
+    indexer.upsert_chunks(
+        [
+            _chunk("a.md", 0, "alpha"),
+            _chunk("b.md", 0, "zzzzz"),
+        ]
+    )
     results = indexer.search("alpha", limit=5, min_score=0.99)
     # Only the self-match (if any) should clear a 0.99 threshold; unrelated
     # vectors must not.
@@ -252,8 +279,10 @@ def test_search_respects_min_score(indexer):
 
 
 def test_search_with_none_filter_value_is_ignored(indexer):
-    indexer.upsert_chunks([
-        _chunk("a.md", 0, "content", metadata={"type": "meeting"}),
-    ])
+    indexer.upsert_chunks(
+        [
+            _chunk("a.md", 0, "content", metadata={"type": "meeting"}),
+        ]
+    )
     results = indexer.search("content", limit=5, min_score=0.0, filters={"type": None})
     assert len(results) == 1

--- a/aios-search/tests/test_main.py
+++ b/aios-search/tests/test_main.py
@@ -43,7 +43,11 @@ def fake_indexer():
 
 
 class _FakeWatcher:
-    def __init__(self, reconcile_block_seconds: float = 0.0, reconcile_raises: Exception | None = None):
+    def __init__(
+        self,
+        reconcile_block_seconds: float = 0.0,
+        reconcile_raises: Exception | None = None,
+    ):
         self._reconcile_block_seconds = reconcile_block_seconds
         self._reconcile_raises = reconcile_raises
         self.started = False
@@ -82,7 +86,9 @@ def test_lifespan_does_not_block_on_slow_reconcile(app_factory, fake_indexer):
         elapsed = time.monotonic() - start
         # TestClient completes lifespan startup before returning from __enter__.
         # If reconcile were awaited synchronously, this would take ~5s.
-        assert elapsed < 2.0, f"Lifespan took {elapsed:.2f}s; reconcile is blocking startup"
+        assert elapsed < 2.0, (
+            f"Lifespan took {elapsed:.2f}s; reconcile is blocking startup"
+        )
         resp = client.get("/health")
         assert resp.status_code == 200
 

--- a/aios-search/tests/test_parser.py
+++ b/aios-search/tests/test_parser.py
@@ -1,7 +1,6 @@
 import hashlib
-from pathlib import Path
 
-from aios_search.parser import NoteChunk, parse_note, should_ignore
+from aios_search.parser import parse_note, should_ignore
 
 
 def test_parse_short_note_single_chunk(tmp_vault):
@@ -25,13 +24,18 @@ def test_parse_long_note_splits_on_headings(tmp_vault):
     chunks = parse_note(path, tmp_vault)
 
     assert len(chunks) == 3
-    assert all(c.file_path == "20-Meetings/2025-10-15 - IT Systems Progress Update.md" for c in chunks)
+    assert all(
+        c.file_path == "20-Meetings/2025-10-15 - IT Systems Progress Update.md"
+        for c in chunks
+    )
     assert chunks[0].chunk_index == 0
     assert chunks[1].chunk_index == 1
     assert chunks[2].chunk_index == 2
     assert all(c.chunk_total == 3 for c in chunks)
     assert "IT Systems Progress Update" in chunks[0].content
-    assert "meeting" in chunks[0].content.lower() or "diixtra" in chunks[0].content.lower()
+    assert (
+        "meeting" in chunks[0].content.lower() or "diixtra" in chunks[0].content.lower()
+    )
 
 
 def test_parse_long_note_no_headings_uses_window(tmp_vault):
@@ -39,7 +43,9 @@ def test_parse_long_note_no_headings_uses_window(tmp_vault):
     chunks = parse_note(path, tmp_vault, chunk_word_window=200, chunk_word_overlap=30)
 
     assert len(chunks) >= 2
-    assert all(c.file_path == "50-Knowledge/Library/Business Framework.md" for c in chunks)
+    assert all(
+        c.file_path == "50-Knowledge/Library/Business Framework.md" for c in chunks
+    )
     assert "Business Framework" in chunks[0].content
 
 
@@ -66,10 +72,21 @@ def test_should_ignore(tmp_vault):
     ignored_dirs = [".obsidian", "80-Dashboards", "90-Templates", ".stfolder"]
     ignored_files = [".stignore", ".DS_Store"]
 
-    assert should_ignore(tmp_vault / "80-Dashboards" / "Home.md", tmp_vault, ignored_dirs, ignored_files)
-    assert should_ignore(tmp_vault / ".obsidian" / "app.json", tmp_vault, ignored_dirs, ignored_files)
-    assert should_ignore(tmp_vault / ".DS_Store", tmp_vault, ignored_dirs, ignored_files)
-    assert not should_ignore(tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md", tmp_vault, ignored_dirs, ignored_files)
+    assert should_ignore(
+        tmp_vault / "80-Dashboards" / "Home.md", tmp_vault, ignored_dirs, ignored_files
+    )
+    assert should_ignore(
+        tmp_vault / ".obsidian" / "app.json", tmp_vault, ignored_dirs, ignored_files
+    )
+    assert should_ignore(
+        tmp_vault / ".DS_Store", tmp_vault, ignored_dirs, ignored_files
+    )
+    assert not should_ignore(
+        tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md",
+        tmp_vault,
+        ignored_dirs,
+        ignored_files,
+    )
 
 
 def test_should_ignore_sync_conflict(tmp_vault):

--- a/aios-search/tests/test_watcher.py
+++ b/aios-search/tests/test_watcher.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-from pathlib import Path
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -37,7 +36,9 @@ def watcher(mock_settings, mock_indexer):
 def test_process_file_calls_indexer(watcher, mock_indexer, tmp_vault):
     path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
     watcher._process_file(path)
-    mock_indexer.delete_by_file_path.assert_called_once_with("12-CRM/Contacts/Shah Ali.md")
+    mock_indexer.delete_by_file_path.assert_called_once_with(
+        "12-CRM/Contacts/Shah Ali.md"
+    )
     mock_indexer.upsert_chunks.assert_called_once()
 
 
@@ -48,7 +49,9 @@ def test_process_file_adds_to_retry_on_failure(watcher, mock_indexer, tmp_vault)
     assert watcher.has_pending_retry("12-CRM/Contacts/Shah Ali.md")
 
 
-def test_process_file_first_failure_logs_exception_with_traceback(watcher, mock_indexer, tmp_vault, caplog):
+def test_process_file_first_failure_logs_exception_with_traceback(
+    watcher, mock_indexer, tmp_vault, caplog
+):
     mock_indexer.upsert_chunks.side_effect = Exception("Qdrant down")
     path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
     with caplog.at_level(logging.WARNING, logger="aios_search.watcher"):
@@ -57,7 +60,9 @@ def test_process_file_first_failure_logs_exception_with_traceback(watcher, mock_
     assert len(exception_records) == 1, "first failure should log with traceback"
 
 
-def test_process_file_subsequent_failures_suppress_traceback(watcher, mock_indexer, tmp_vault, caplog):
+def test_process_file_subsequent_failures_suppress_traceback(
+    watcher, mock_indexer, tmp_vault, caplog
+):
     mock_indexer.upsert_chunks.side_effect = Exception("Qdrant down")
     path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
     watcher._process_file(path)
@@ -91,12 +96,15 @@ def test_process_retries_respects_backoff(watcher, mock_indexer, tmp_vault):
     assert mock_indexer.upsert_chunks.call_count == initial_call_count
 
 
-def test_process_retries_fires_when_backoff_elapsed(watcher, mock_indexer, tmp_vault, monkeypatch):
+def test_process_retries_fires_when_backoff_elapsed(
+    watcher, mock_indexer, tmp_vault, monkeypatch
+):
     mock_indexer.upsert_chunks.side_effect = Exception("Qdrant down")
     path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
     watcher._process_file(path)
     # Force the backoff to elapse by fast-forwarding the monotonic clock.
     from aios_search import watcher as watcher_mod
+
     original = watcher_mod.time.monotonic
     monkeypatch.setattr(watcher_mod.time, "monotonic", lambda: original() + 3600)
     call_count_before = mock_indexer.upsert_chunks.call_count
@@ -107,7 +115,9 @@ def test_process_retries_fires_when_backoff_elapsed(watcher, mock_indexer, tmp_v
 def test_process_delete(watcher, mock_indexer, tmp_vault):
     path = tmp_vault / "12-CRM" / "Contacts" / "Shah Ali.md"
     watcher._process_delete(path)
-    mock_indexer.delete_by_file_path.assert_called_once_with("12-CRM/Contacts/Shah Ali.md")
+    mock_indexer.delete_by_file_path.assert_called_once_with(
+        "12-CRM/Contacts/Shah Ali.md"
+    )
 
 
 def test_reconcile_indexes_missing_files(watcher, mock_indexer, tmp_vault):
@@ -126,7 +136,8 @@ def test_reconcile_removes_orphans(watcher, mock_indexer, tmp_vault):
     }
     watcher.reconcile()
     delete_calls = [
-        c for c in mock_indexer.delete_by_file_path.call_args_list
+        c
+        for c in mock_indexer.delete_by_file_path.call_args_list
         if c == call("deleted-note.md")
     ]
     assert len(delete_calls) == 1

--- a/mcp-proxy/src/mcp_sampling_proxy/__main__.py
+++ b/mcp-proxy/src/mcp_sampling_proxy/__main__.py
@@ -45,9 +45,7 @@ async def _run() -> None:
         await upstream.disconnect()
 
     for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(
-            sig, lambda: asyncio.ensure_future(shutdown())
-        )
+        loop.add_signal_handler(sig, lambda: asyncio.ensure_future(shutdown()))
 
     try:
         await proxy_task

--- a/mcp-proxy/src/mcp_sampling_proxy/proxy_server.py
+++ b/mcp-proxy/src/mcp_sampling_proxy/proxy_server.py
@@ -56,11 +56,15 @@ class ProxyServer:
         @self._server.call_tool()
         async def handle_call_tool(
             name: str, arguments: dict[str, Any] | None
-        ) -> list[mcp_types.TextContent | mcp_types.ImageContent | mcp_types.EmbeddedResource]:
+        ) -> list[
+            mcp_types.TextContent | mcp_types.ImageContent | mcp_types.EmbeddedResource
+        ]:
             _debug(config, f"tool call: {name}")
             if not self._upstream:
                 raise McpError(
-                    mcp_types.ErrorData(code=mcp_types.INTERNAL_ERROR, message="No upstream connection")
+                    mcp_types.ErrorData(
+                        code=mcp_types.INTERNAL_ERROR, message="No upstream connection"
+                    )
                 )
             result = await self._upstream.call_tool(name, arguments or {})
             return result.content

--- a/mcp-proxy/src/mcp_sampling_proxy/sampling.py
+++ b/mcp-proxy/src/mcp_sampling_proxy/sampling.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 def _raise(code: int, message: str) -> None:
     raise McpError(mcp_types.ErrorData(code=code, message=message))
 
+
 # claude stop_reason → MCP stopReason
 _STOP_REASON_MAP: dict[str, str] = {
     "end_turn": "endTurn",

--- a/mcp-proxy/src/mcp_sampling_proxy/upstream.py
+++ b/mcp-proxy/src/mcp_sampling_proxy/upstream.py
@@ -68,7 +68,9 @@ class UpstreamClient:
                         name=t.name,
                         description=t.description,
                         input_schema=t.inputSchema,
-                        output_schema=t.outputSchema if hasattr(t, "outputSchema") else None,
+                        output_schema=t.outputSchema
+                        if hasattr(t, "outputSchema")
+                        else None,
                     )
                 )
             cursor = result.nextCursor
@@ -84,7 +86,9 @@ class UpstreamClient:
         """Forward a tool call to the upstream server."""
         if not self._session:
             raise McpError(
-                mcp_types.ErrorData(code=mcp_types.INTERNAL_ERROR, message="Not connected to upstream")
+                mcp_types.ErrorData(
+                    code=mcp_types.INTERNAL_ERROR, message="Not connected to upstream"
+                )
             )
         _debug(self._config, f"calling upstream tool: {name}")
         return await self._session.call_tool(name, arguments)

--- a/mcp-proxy/tests/test_config.py
+++ b/mcp-proxy/tests/test_config.py
@@ -36,8 +36,9 @@ class TestLoadConfig:
             "SAMPLING_TIMEOUT_S": "60",
             "DEBUG": "true",
         }
-        with mock.patch.dict(os.environ, env, clear=False), mock.patch(
-            "sys.argv", ["prog"]
+        with (
+            mock.patch.dict(os.environ, env, clear=False),
+            mock.patch("sys.argv", ["prog"]),
         ):
             cfg = load_config()
         assert cfg.upstream_url == "http://upstream:9090"
@@ -46,31 +47,36 @@ class TestLoadConfig:
         assert cfg.debug is True
 
     def test_missing_upstream_url_exits(self) -> None:
-        with mock.patch.dict(os.environ, {}, clear=True), mock.patch(
-            "sys.argv", ["prog"]
-        ), pytest.raises(SystemExit):
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("sys.argv", ["prog"]),
+            pytest.raises(SystemExit),
+        ):
             load_config()
 
     def test_cli_args_override_env(self) -> None:
         env = {"UPSTREAM_URL": "http://from-env:1234"}
-        with mock.patch.dict(os.environ, env, clear=False), mock.patch(
-            "sys.argv", ["prog", "--upstream-url", "http://from-arg:5678"]
+        with (
+            mock.patch.dict(os.environ, env, clear=False),
+            mock.patch("sys.argv", ["prog", "--upstream-url", "http://from-arg:5678"]),
         ):
             cfg = load_config()
         assert cfg.upstream_url == "http://from-arg:5678"
 
     def test_debug_flag_from_env_value_1(self) -> None:
         env = {"UPSTREAM_URL": "http://x", "DEBUG": "1"}
-        with mock.patch.dict(os.environ, env, clear=False), mock.patch(
-            "sys.argv", ["prog"]
+        with (
+            mock.patch.dict(os.environ, env, clear=False),
+            mock.patch("sys.argv", ["prog"]),
         ):
             cfg = load_config()
         assert cfg.debug is True
 
     def test_debug_flag_off_by_default(self) -> None:
         env = {"UPSTREAM_URL": "http://x"}
-        with mock.patch.dict(os.environ, env, clear=False), mock.patch(
-            "sys.argv", ["prog"]
+        with (
+            mock.patch.dict(os.environ, env, clear=False),
+            mock.patch("sys.argv", ["prog"]),
         ):
             cfg = load_config()
         assert cfg.debug is False

--- a/mcp-proxy/tests/test_sampling.py
+++ b/mcp-proxy/tests/test_sampling.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from unittest import mock
 
@@ -18,24 +17,34 @@ from mcp_sampling_proxy.sampling import SamplingExecutor, _STOP_REASON_MAP
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_config(**overrides: object) -> Config:
     defaults = {"upstream_url": "http://upstream:8080", "claude_path": "claude"}
     return Config(**{**defaults, **overrides})
 
 
-def _stream_json_line(msg_type: str, content: list[dict], stop_reason: str = "end_turn", model: str = "claude-test") -> str:
-    return json.dumps({
-        "type": msg_type,
-        "message": {
-            "role": "assistant",
-            "content": content,
-            "stop_reason": stop_reason,
-            "model": model,
-        },
-    })
+def _stream_json_line(
+    msg_type: str,
+    content: list[dict],
+    stop_reason: str = "end_turn",
+    model: str = "claude-test",
+) -> str:
+    return json.dumps(
+        {
+            "type": msg_type,
+            "message": {
+                "role": "assistant",
+                "content": content,
+                "stop_reason": stop_reason,
+                "model": model,
+            },
+        }
+    )
 
 
-def _make_params(text: str = "hello", system: str | None = None) -> mcp_types.CreateMessageRequestParams:
+def _make_params(
+    text: str = "hello", system: str | None = None
+) -> mcp_types.CreateMessageRequestParams:
     return mcp_types.CreateMessageRequestParams(
         messages=[
             mcp_types.SamplingMessage(
@@ -62,6 +71,7 @@ def _mock_process(stdout: str, returncode: int = 0, stderr: str = "") -> mock.As
 # Tests: stop-reason mapping
 # ---------------------------------------------------------------------------
 
+
 class TestStopReasonMap:
     def test_all_known_mappings(self) -> None:
         assert _STOP_REASON_MAP["end_turn"] == "endTurn"
@@ -74,10 +84,13 @@ class TestStopReasonMap:
 # Tests: SamplingExecutor.execute
 # ---------------------------------------------------------------------------
 
+
 class TestSamplingExecutor:
     @pytest.mark.asyncio
     async def test_simple_text_response(self) -> None:
-        stdout = _stream_json_line("assistant", [{"type": "text", "text": "Hello world"}])
+        stdout = _stream_json_line(
+            "assistant", [{"type": "text", "text": "Hello world"}]
+        )
         proc = _mock_process(stdout)
 
         with mock.patch("asyncio.create_subprocess_exec", return_value=proc):
@@ -92,8 +105,12 @@ class TestSamplingExecutor:
     @pytest.mark.asyncio
     async def test_uses_last_assistant_message(self) -> None:
         """After Issue 11 fix: should use LAST assistant message, not first."""
-        first = _stream_json_line("assistant", [{"type": "text", "text": "first response"}])
-        second = _stream_json_line("assistant", [{"type": "text", "text": "final response"}])
+        first = _stream_json_line(
+            "assistant", [{"type": "text", "text": "first response"}]
+        )
+        second = _stream_json_line(
+            "assistant", [{"type": "text", "text": "final response"}]
+        )
         stdout = first + "\n" + second
         proc = _mock_process(stdout)
 
@@ -105,7 +122,12 @@ class TestSamplingExecutor:
 
     @pytest.mark.asyncio
     async def test_tool_use_response(self) -> None:
-        tool_block = {"type": "tool_use", "id": "t1", "name": "bash", "input": {"cmd": "ls"}}
+        tool_block = {
+            "type": "tool_use",
+            "id": "t1",
+            "name": "bash",
+            "input": {"cmd": "ls"},
+        }
         stdout = _stream_json_line("assistant", [tool_block], stop_reason="tool_use")
         proc = _mock_process(stdout)
 
@@ -141,7 +163,9 @@ class TestSamplingExecutor:
         stdout = _stream_json_line("assistant", [{"type": "text", "text": "ok"}])
         proc = _mock_process(stdout)
 
-        with mock.patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+        with mock.patch(
+            "asyncio.create_subprocess_exec", return_value=proc
+        ) as mock_exec:
             executor = SamplingExecutor(_make_config())
             await executor.execute(_make_params("hi", system="Be helpful"))
 
@@ -162,10 +186,13 @@ class TestSamplingExecutor:
 
     @pytest.mark.asyncio
     async def test_multiple_text_blocks_joined(self) -> None:
-        stdout = _stream_json_line("assistant", [
-            {"type": "text", "text": "Hello"},
-            {"type": "text", "text": "World"},
-        ])
+        stdout = _stream_json_line(
+            "assistant",
+            [
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "World"},
+            ],
+        )
         proc = _mock_process(stdout)
 
         with mock.patch("asyncio.create_subprocess_exec", return_value=proc):

--- a/voice/src/config.py
+++ b/voice/src/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/voice/src/gateway.py
+++ b/voice/src/gateway.py
@@ -34,14 +34,10 @@ async def healthz() -> JSONResponse:
 @app.get("/")
 async def index() -> FileResponse:
     """Serve the push-to-talk UI."""
-    return FileResponse(
-        STATIC_DIR / "index.html", media_type="text/html"
-    )
+    return FileResponse(STATIC_DIR / "index.html", media_type="text/html")
 
 
-async def _get_claude_response(
-    task_name: str, transcript: list[dict[str, str]]
-) -> str:
+async def _get_claude_response(task_name: str, transcript: list[dict[str, str]]) -> str:
     """Call the Anthropic API with the session transcript and return the response.
 
     Args:
@@ -126,12 +122,9 @@ async def voice_ws(
 
             # Step 2: Generate agent response via Claude API
             transcript_for_claude = [
-                {"role": e.role, "content": e.text}
-                for e in session.transcript
+                {"role": e.role, "content": e.text} for e in session.transcript
             ]
-            agent_text = await _get_claude_response(
-                task_name, transcript_for_claude
-            )
+            agent_text = await _get_claude_response(task_name, transcript_for_claude)
             session.add_agent_message(agent_text)
 
             # Step 3: Send text transcript to client
@@ -159,8 +152,7 @@ async def voice_ws(
                 await slack.post_transcript(channel, thread, transcript_text)
             except Exception:
                 logger.exception(
-                    "Failed to post voice transcript to Slack "
-                    "channel=%s thread=%s",
+                    "Failed to post voice transcript to Slack channel=%s thread=%s",
                     channel,
                     thread,
                 )

--- a/voice/src/localai.py
+++ b/voice/src/localai.py
@@ -15,9 +15,7 @@ class LocalAIClient:
         self.whisper_model = config.whisper_model
         self.tts_model = config.tts_model
 
-    async def transcribe(
-        self, audio_bytes: bytes, model: str | None = None
-    ) -> str:
+    async def transcribe(self, audio_bytes: bytes, model: str | None = None) -> str:
         """Transcribe audio bytes to text via LocalAI Whisper endpoint.
 
         Args:
@@ -39,9 +37,7 @@ class LocalAIClient:
             data = response.json()
             return data.get("text", "")
 
-    async def synthesize(
-        self, text: str, model: str | None = None
-    ) -> bytes:
+    async def synthesize(self, text: str, model: str | None = None) -> bytes:
         """Synthesize text to audio via LocalAI Piper TTS endpoint.
 
         Args:

--- a/voice/src/session.py
+++ b/voice/src/session.py
@@ -46,13 +46,9 @@ class SessionManager:
     def __init__(self) -> None:
         self._sessions: dict[str, VoiceSession] = {}
 
-    def create(
-        self, task_name: str, task_namespace: str = "default"
-    ) -> VoiceSession:
+    def create(self, task_name: str, task_namespace: str = "default") -> VoiceSession:
         """Create a new voice session for a task."""
-        session = VoiceSession(
-            task_name=task_name, task_namespace=task_namespace
-        )
+        session = VoiceSession(task_name=task_name, task_namespace=task_namespace)
         self._sessions[task_name] = session
         return session
 

--- a/voice/tests/test_gateway.py
+++ b/voice/tests/test_gateway.py
@@ -8,7 +8,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from starlette.testclient import TestClient
 
-from src.gateway import _get_claude_response, app, config
+from src.gateway import _get_claude_response, app
 
 
 @pytest.mark.asyncio
@@ -41,9 +41,7 @@ async def test_get_claude_response_calls_api() -> None:
 
     mock_client_instance = AsyncMock()
     mock_client_instance.post.return_value = mock_response
-    mock_client_instance.__aenter__ = AsyncMock(
-        return_value=mock_client_instance
-    )
+    mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
     mock_client_instance.__aexit__ = AsyncMock(return_value=False)
 
     with patch("src.gateway.httpx.AsyncClient", return_value=mock_client_instance):
@@ -75,9 +73,7 @@ async def test_get_claude_response_maps_agent_to_assistant() -> None:
 
     mock_client_instance = AsyncMock()
     mock_client_instance.post.return_value = mock_response
-    mock_client_instance.__aenter__ = AsyncMock(
-        return_value=mock_client_instance
-    )
+    mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
     mock_client_instance.__aexit__ = AsyncMock(return_value=False)
 
     with patch("src.gateway.httpx.AsyncClient", return_value=mock_client_instance):
@@ -128,6 +124,6 @@ def test_ws_accepts_valid_token() -> None:
     fake_config = VoiceConfig(voice_auth_token="secret-token")
     client = TestClient(app)
     with patch("src.gateway.config", fake_config):
-        with client.websocket_connect("/ws/test-task?token=secret-token") as ws:
+        with client.websocket_connect("/ws/test-task?token=secret-token"):
             # Connection accepted; close cleanly
             pass

--- a/voice/tests/test_session.py
+++ b/voice/tests/test_session.py
@@ -1,6 +1,6 @@
 """Tests for voice session management."""
 
-from src.session import VoiceSession, SessionManager, TranscriptEntry
+from src.session import VoiceSession, SessionManager
 
 
 class TestVoiceSession:

--- a/voice/tests/test_slack_integration.py
+++ b/voice/tests/test_slack_integration.py
@@ -13,7 +13,11 @@ class TestSlackVoiceIntegration:
     @pytest.mark.asyncio
     async def test_post_transcript_calls_slack_api(self) -> None:
         mock_client = AsyncMock()
-        with patch.object(SlackVoiceIntegration, "__init__", lambda self, token: setattr(self, "client", mock_client)):
+        with patch.object(
+            SlackVoiceIntegration,
+            "__init__",
+            lambda self, token: setattr(self, "client", mock_client),
+        ):
             integration = SlackVoiceIntegration(token="xoxb-test-token")
 
             await integration.post_transcript(
@@ -31,7 +35,11 @@ class TestSlackVoiceIntegration:
     @pytest.mark.asyncio
     async def test_post_transcript_formats_message(self) -> None:
         mock_client = AsyncMock()
-        with patch.object(SlackVoiceIntegration, "__init__", lambda self, token: setattr(self, "client", mock_client)):
+        with patch.object(
+            SlackVoiceIntegration,
+            "__init__",
+            lambda self, token: setattr(self, "client", mock_client),
+        ):
             integration = SlackVoiceIntegration(token="xoxb-test")
 
             await integration.post_transcript(


### PR DESCRIPTION
Apply `uvx ruff check --fix .` and `uvx ruff format .` on `aios-search`, `aios-search/mcp`, `mcp-proxy`, `voice`. Mostly auto-fixed F401 unused imports + whitespace/quote/line-break formatting. One manual fix in `voice/tests/test_gateway.py`: drop unused `as ws` binding in websocket_connect context manager.

All 4 sub-packages now pass ruff check + format-check locally.

Refs Diixtra/diixtra-forge#1636.