### PR TITLE
fix: address remaining Go matrix findings (#115)

### DIFF
--- a/operator/.golangci.yml
+++ b/operator/.golangci.yml
@@ -35,13 +35,21 @@ linters:
           - lll
       # Test files use idiomatic patterns that trigger style linters benignly:
       # repeated string literals as test data, unchecked errors on cleanup helpers,
-      # ineffectual assignments in mock setup, slice prealloc on small fixtures.
+      # ineffectual assignments in mock setup, slice prealloc on small fixtures,
+      # and intentional use of deprecated APIs (Result.Requeue, etc.) for
+      # backwards-compat coverage.
       - path: "_test\\.go"
         linters:
           - goconst
           - errcheck
           - ineffassign
           - prealloc
+          - staticcheck
+      # Test utilities under test/ use dot imports for ginkgo and other patterns
+      # that staticcheck flags as style violations.
+      - path: "test/.*\\.go"
+        linters:
+          - staticcheck
   settings:
     revive:
       rules:

--- a/operator/api/v1alpha1/groupversion_info.go
+++ b/operator/api/v1alpha1/groupversion_info.go
@@ -29,6 +29,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "aios.kazie.co.uk", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionResource scheme.
+	//
+	//nolint:staticcheck // SA1019: scheme.Builder is the kubebuilder-generated
+	// helper. Migrating away requires moving the registration into a non-api
+	// package per controller-runtime guidance — tracked separately.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/operator/test/utils/utils.go
+++ b/operator/test/utils/utils.go
@@ -197,7 +197,7 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }
 

--- a/ticktick-sync/internal/sync/engine.go
+++ b/ticktick-sync/internal/sync/engine.go
@@ -70,7 +70,9 @@ func (e *Engine) PollTickTick(ctx context.Context) error {
 					slog.Error("failed to close issue", "error", err)
 				} else {
 					m.Closed = true
-					e.store.AddMapping(ctx, *m)
+					if err := e.store.AddMapping(ctx, *m); err != nil {
+						slog.Error("add mapping failed", "error", err)
+					}
 				}
 			}
 			continue
@@ -105,13 +107,15 @@ func (e *Engine) PollTickTick(ctx context.Context) error {
 			continue
 		}
 
-		e.store.AddMapping(ctx, state.Mapping{
+		if err := e.store.AddMapping(ctx, state.Mapping{
 			TickTickProjectID: task.ProjectID,
 			TickTickTaskID:    task.ID,
 			GitHubRepo:        targetRepo,
 			GitHubIssueNumber: issue.Number,
 			LastSyncedAt:      time.Now(),
-		})
+		}); err != nil {
+			slog.Error("add mapping failed", "error", err)
+		}
 	}
 
 	e.store.SetLastTickTickPoll(ctx, time.Now())
@@ -137,7 +141,9 @@ func (e *Engine) HandleIssueClosed(ctx context.Context, repo string, issueNumber
 	}
 
 	m.Closed = true
-	e.store.AddMapping(ctx, *m)
+	if err := e.store.AddMapping(ctx, *m); err != nil {
+		slog.Error("add mapping failed", "error", err)
+	}
 
 	if err := e.store.Flush(ctx); err != nil {
 		slog.Error("state flush failed", "error", err)
@@ -182,13 +188,15 @@ func (e *Engine) HandleIssueLabeled(ctx context.Context, repo string, issueNumbe
 		slog.Error("failed to update issue body with marker", "error", err)
 	}
 
-	e.store.AddMapping(ctx, state.Mapping{
+	if err := e.store.AddMapping(ctx, state.Mapping{
 		TickTickProjectID: e.projectID,
 		TickTickTaskID:    task.ID,
 		GitHubRepo:        repo,
 		GitHubIssueNumber: issueNumber,
 		LastSyncedAt:      time.Now(),
-	})
+	}); err != nil {
+		slog.Error("add mapping failed", "error", err)
+	}
 
 	if err := e.store.Flush(ctx); err != nil {
 		slog.Error("state flush failed", "error", err)

--- a/ticktick-sync/internal/ticktick/client.go
+++ b/ticktick-sync/internal/ticktick/client.go
@@ -97,10 +97,10 @@ func (c *Client) CompleteTask(ctx context.Context, projectID, taskID string) err
 	if err != nil {
 		return fmt.Errorf("complete task: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized && c.refreshToken != "" {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err := c.refreshAccessToken(ctx); err != nil {
 			return fmt.Errorf("token refresh failed: %w", err)
 		}
@@ -108,7 +108,7 @@ func (c *Client) CompleteTask(ctx context.Context, projectID, taskID string) err
 		if err != nil {
 			return fmt.Errorf("complete task after refresh: %w", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 	}
 
 	if resp.StatusCode >= 400 {
@@ -123,10 +123,10 @@ func (c *Client) get(ctx context.Context, path string, out interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized && c.refreshToken != "" {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err := c.refreshAccessToken(ctx); err != nil {
 			return fmt.Errorf("token refresh failed: %w", err)
 		}
@@ -134,7 +134,7 @@ func (c *Client) get(ctx context.Context, path string, out interface{}) error {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 	}
 
 	if resp.StatusCode >= 400 {
@@ -150,10 +150,10 @@ func (c *Client) post(ctx context.Context, path string, body []byte, out interfa
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized && c.refreshToken != "" {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err := c.refreshAccessToken(ctx); err != nil {
 			return fmt.Errorf("token refresh failed: %w", err)
 		}
@@ -161,7 +161,7 @@ func (c *Client) post(ctx context.Context, path string, body []byte, out interfa
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 	}
 
 	if resp.StatusCode >= 400 {
@@ -217,7 +217,7 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(resp.Body)

--- a/ticktick-sync/internal/webhook/handler.go
+++ b/ticktick-sync/internal/webhook/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	signature := r.Header.Get("X-Hub-Signature-256")
 	if !validSignature(h.secret, body, signature) {
@@ -66,7 +66,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	eventType := r.Header.Get("X-GitHub-Event")
 	if eventType != "issues" {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "ignored event")
+		_, _ = fmt.Fprint(w, "ignored event")
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "labeled":
 		if event.Label.Name != "agent" {
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "ignored label")
+			_, _ = fmt.Fprint(w, "ignored label")
 			return
 		}
 		slog.Info("webhook: issue labeled agent", "repo", event.Repository.FullName, "issue", event.Issue.Number)
@@ -100,12 +100,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	default:
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "ignored action")
+		_, _ = fmt.Fprint(w, "ignored action")
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, "ok")
+	_, _ = fmt.Fprint(w, "ok")
 }
 
 func validSignature(secret, payload []byte, signature string) bool {


### PR DESCRIPTION
Round 2 of Go enforce-mode fixes after #135. Production-code errcheck (engine.go, client.go, handler.go) + staticcheck suppressions for SchemeBuilder + ReplaceAll mechanical fix + relax staticcheck on _test.go and test/ utility paths. `go build ./...` clean. Refs Diixtra/diixtra-forge#1636.