### PR TITLE
fix(webhook): paperless + github handler errcheck (#115)

### DIFF
--- a/webhook/internal/github/handler.go
+++ b/webhook/internal/github/handler.go
@@ -121,7 +121,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	fmt.Fprint(w, "task created")
+	_, _ = fmt.Fprint(w, "task created")
 }
 
 // validSignature checks the HMAC-SHA256 signature of the payload.

--- a/webhook/internal/paperless/client.go
+++ b/webhook/internal/paperless/client.go
@@ -145,7 +145,7 @@ func (c *Client) get(ctx context.Context, path string, dest any) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status %d for %s", resp.StatusCode, path)
@@ -171,7 +171,7 @@ func (c *Client) post(ctx context.Context, path string, body any, dest any) erro
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status %d for POST %s", resp.StatusCode, path)
@@ -200,7 +200,7 @@ func (c *Client) patch(ctx context.Context, path string, body any) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status %d for PATCH %s", resp.StatusCode, path)

--- a/webhook/internal/paperless/handler.go
+++ b/webhook/internal/paperless/handler.go
@@ -111,7 +111,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "processed document %d", doc.ID)
+	_, _ = fmt.Fprintf(w, "processed document %d", doc.ID)
 }
 
 // applyTags resolves suggested tag names to IDs and updates the document.
@@ -184,7 +184,7 @@ func (h *Handler) autoLink(ctx context.Context, doc *document.Document) (int, er
 	if err != nil {
 		return 0, fmt.Errorf("search request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var searchResp searchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&searchResp); err != nil {


### PR DESCRIPTION
Round 3 of Go enforce-mode fixes after #138. Wrap remaining errcheck violations in webhook/internal/paperless/* + the line-124 fmt.Fprint in webhook/internal/github/handler.go missed in #135. `go build ./...` clean. Refs Diixtra/diixtra-forge#1636.