### PR TITLE
fix(operator): relax goconst on internal/ (#115)

### DIFF
--- a/operator/.golangci.yml
+++ b/operator/.golangci.yml
@@ -33,6 +33,7 @@ linters:
         linters:
           - dupl
           - lll
+          - goconst
       # Test files use idiomatic patterns that trigger style linters benignly:
       # repeated string literals as test data, unchecked errors on cleanup helpers,
       # ineffectual assignments in mock setup, slice prealloc on small fixtures,


### PR DESCRIPTION
Add goconst to operator/.golangci.yml internal/* exclusion. Refs Diixtra/diixtra-forge#1636.